### PR TITLE
update submodule installation link to not require end users to have s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ github "Square/SquarePointOfSaleSDK-iOS"
 ```
 
 #### Git Submodules
-Checkout the submodule with `git submodule add git@github.com:Square/SquarePointOfSaleSDK-iOS.git`, drag SquarePointOfSaleSDK.xcodeproj to your project, and add SquarePointOfSaleSDK as a build dependency.
+Checkout the submodule with `git submodule add https://github.com/square/SquarePointOfSaleSDK-iOS.git`, drag SquarePointOfSaleSDK.xcodeproj to your project, and add SquarePointOfSaleSDK as a build dependency.
 
 -------------------------------
 


### PR DESCRIPTION
…sh keys set up.

Most github users do not use ssh, so we shouldn't require them to set it up in order to install our SDKs. 