### PR TITLE
Fixed an error during installation

### DIFF
--- a/Sources/SCCAPIConnection.m
+++ b/Sources/SCCAPIConnection.m
@@ -86,11 +86,12 @@
         return NO;
     }
 
-    if (@available(iOS 10, *)) {
+    #if TARGET_OS_IOS && __IPHONE_OS_VERSION_MAX_ALLOWED >= 100000
+        // Processing when iOS version is 10.0 or later
         [[UIApplication sharedApplication] openURL:URL options:@{} completionHandler:nil];
-    } else {
+    #else
         return [[UIApplication sharedApplication] openURL:URL];
-    }
+    #endif
 
     return YES;
 }

--- a/SquarePointOfSaleSDK.podspec
+++ b/SquarePointOfSaleSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'SquarePointOfSaleSDK'
-  s.version      = '3.5.0'
+  s.version      = '3.5.1'
   s.summary      = 'SDK for easier use of Square\'s Point of Sale app-switching API on iOS'
   s.homepage     = 'https://github.com/square/SquarePointOfSaleSDK-iOS/'
   s.license      = { :type => 'Apache License, Version 2.0', :text => "© #{ Date.today.year } Square, Inc." }


### PR DESCRIPTION
I had a problem installing the Square POS iOS SDK via CocoaPods, so I fixed it.  The if was not working and I was always getting the following error.

`'openURL:' is deprecated: first deprecated in iOS 10.0`

### Image
![image](https://user-images.githubusercontent.com/43707/121862906-3ec5a380-cd36-11eb-9ead-5b7b9549508a.png)

### Relation
- [Errors installing Square POS iOS SDK - Questions - Square Developer Forums](https://developer.squareup.com/forums/t/errors-installing-square-pos-ios-sdk/2649)
- [Issues installing this dependency · Issue #100 · square/SquarePointOfSaleSDK-iOS](https://github.com/square/SquarePointOfSaleSDK-iOS/issues/100)