### PR TITLE
Updated the OS version to the one supported in CI

### DIFF
--- a/.github/workflows/xcodebuild.yml
+++ b/.github/workflows/xcodebuild.yml
@@ -19,5 +19,5 @@ jobs:
           xcodebuild \
             -scheme SquarePointOfSaleSDK \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 12,OS=14.4' \
+            -destination 'platform=iOS Simulator,name=iPhone 12,OS=15.2' \
             test


### PR DESCRIPTION
issue: https://github.com/square/SquarePointOfSaleSDK-iOS/issues/132 

Here's a sample failure that this PR fixes: https://github.com/square/SquarePointOfSaleSDK-iOS/runs/8264351743?check_suite_focus=true 