### PR TITLE
Adding PayPay Tender support

### DIFF
--- a/.github/workflows/xcodebuild.yml
+++ b/.github/workflows/xcodebuild.yml
@@ -19,5 +19,5 @@ jobs:
           xcodebuild \
             -scheme SquarePointOfSaleSDK \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.1'\
+            -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.2'\
             test

--- a/Sources/Public/SCCAPIRequest.h
+++ b/Sources/Public/SCCAPIRequest.h
@@ -43,7 +43,10 @@ typedef NS_OPTIONS(NSUInteger, SCCAPIRequestTenderTypes) {
     SCCAPIRequestTenderTypeSquareGiftCard = 1 << 3,
 
     /// Allow the merchant to accept Square customers' cards on file to complete the payment.
-    SCCAPIRequestTenderTypeCardOnFile = 1 << 4
+    SCCAPIRequestTenderTypeCardOnFile = 1 << 4,
+    
+    /// Allow the merchant to accept Square customers' PayPay tender to complete the payment.
+    SCCAPIRequestTenderTypePayPay = 1 << 5
 };
 
 

--- a/Sources/SCCAPIRequest.m
+++ b/Sources/SCCAPIRequest.m
@@ -49,6 +49,7 @@ NSString *__nonnull const SCCAPIRequestOptionsTenderTypeStringCash = @"CASH";
 NSString *__nonnull const SCCAPIRequestOptionsTenderTypeStringOther = @"OTHER";
 NSString *__nonnull const SCCAPIRequestOptionsTenderTypeStringSquareGiftCard = @"SQUARE_GIFT_CARD";
 NSString *__nonnull const SCCAPIRequestOptionsTenderTypeStringCardOnFile = @"CARD_ON_FILE";
+NSString *__nonnull const SCCAPIRequestOptionsTenderTypeStringPayPay = @"PAYPAY";
 NSString *__nonnull const SCCAPIRequestLocationIDKey = @"location_id";
 
 @interface SCCAPIRequest ()
@@ -360,6 +361,10 @@ NSArray<NSString *> *__nonnull NSArrayOfTenderTypeStringsFromSCCAPIRequestTender
 
     if (tenderTypes & SCCAPIRequestTenderTypeCardOnFile) {
         [arrayOfTenderTypes addObject:SCCAPIRequestOptionsTenderTypeStringCardOnFile];
+    }
+    
+    if (tenderTypes & SCCAPIRequestTenderTypePayPay) {
+        [arrayOfTenderTypes addObject:SCCAPIRequestOptionsTenderTypeStringPayPay];
     }
 
     return arrayOfTenderTypes;

--- a/Tests/SCCAPIRequestTests.swift
+++ b/Tests/SCCAPIRequestTests.swift
@@ -431,6 +431,7 @@ class SCCAPIRequestTests: XCTestCase {
             "OTHER",
             "SQUARE_GIFT_CARD",
             "CARD_ON_FILE",
+            "PAYPAY",
         ])
     }
 


### PR DESCRIPTION
Description:
- Added new PayPay tender type to `SCCAPIRequestTenderTypes`
- Added string value for PayPay in `SCCAPIRequest` which will be used to append PayPay as supported tender in url. 
- Updated tests to ensure that PayPay is returned when selecting all tenders.
- Xcodebuilder couldn't find an iPhone 14 sim with 16.1, updated to 16.2 to get test runner to work again.

Testing Method:
- Tested using provided sample app to ensure PayPay is included in API request
```
square-commerce-v1://payment/create?data={"notes":"Coffee","callback_url":"momoney-x-callback:\/\/square_request","version":"1.3","amount_money":{"amount":100,"currency_code":"JPY"},"options":{"auto_return":false,"skip_receipt":false,"clear_default_fees":false,"disable_cnp":false,"supported_tender_types":["CREDIT_CARD","CASH","OTHER","SQUARE_GIFT_CARD","CARD_ON_FILE","PAYPAY"]},"client_id":"B8A5H2gGPRsktRZDg5a_XQ","sdk_version":"3.5.0"}
``` 
- Ran unit tests to ensure all tests are successful