### PR TITLE
Bump Version To 3.5.4

### DIFF
--- a/SquarePointOfSaleSDK.podspec
+++ b/SquarePointOfSaleSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'SquarePointOfSaleSDK'
-  s.version      = '3.5.3'
+  s.version      = '3.5.4'
   s.summary      = 'SDK for easier use of Square\'s Point of Sale app-switching API on iOS'
   s.homepage     = 'https://github.com/square/SquarePointOfSaleSDK-iOS/'
   s.license      = { :type => 'Apache License, Version 2.0', :text => "© #{ Date.today.year } Square, Inc." }


### PR DESCRIPTION
In preparation for Square Point of Sale SDK release, we need to bump the version number in the podspec